### PR TITLE
Bump ScribanTemplates to v2.7.0 and add README

### DIFF
--- a/MtconnectTranspiler.CodeGenerators.ScribanTemplates/MtconnectTranspiler.CodeGenerators.ScribanTemplates.csproj
+++ b/MtconnectTranspiler.CodeGenerators.ScribanTemplates/MtconnectTranspiler.CodeGenerators.ScribanTemplates.csproj
@@ -1,16 +1,17 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
 	  <TargetFramework>netstandard2.0</TargetFramework>
 	  <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
 	  <Title>MTConnect Transpiler Code Generator for Scriban Templates</Title>
-	  <Version>2.6.0.0</Version>
+	  <Version>2.7.0.0</Version>
 	  <Authors>mtconnect, tbm0115</Authors>
 	  <Company>MTConnect Institute; TAMS;</Company>
 	  <Description>An implementation of `ITranspilerSink` from the `MtconnectTranspiler` library. This libary makes it possible to transpile the MTConnect Standard SysML model into other formats with the help of Scriban templates.</Description>
 	  <RepositoryType>git</RepositoryType>
 	  <PackageTags>MTConnect;Transpiler;CI;Scriban;</PackageTags>
 	  <PackageProjectUrl>https://github.com/mtconnect/MtconnectTranspiler.CodeGenerators.ScribanTemplates</PackageProjectUrl>
+	  <PackageReadmeFile>README.md</PackageReadmeFile>
 	  <RepositoryUrl>https://github.com/mtconnect/MtconnectTranspiler.CodeGenerators.ScribanTemplates</RepositoryUrl>
 	  <GenerateDocumentationFile>True</GenerateDocumentationFile>
 	  <IncludeSymbols>True</IncludeSymbols>
@@ -18,12 +19,16 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <None Update="README.md" Pack="true" PackagePath="\" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="CaseExtensions" Version="1.1.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.9" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.9" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="9.0.9" />
-    <PackageReference Include="MtconnectTranspiler" Version="2.6.1" />
-    <PackageReference Include="Scriban" Version="6.4.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.9" />
+    <PackageReference Include="MtconnectTranspiler" Version="2.7.0" />
+    <PackageReference Include="Scriban" Version="7.2.4" />
   </ItemGroup>
 
 </Project>

--- a/MtconnectTranspiler.CodeGenerators.ScribanTemplates/README.md
+++ b/MtconnectTranspiler.CodeGenerators.ScribanTemplates/README.md
@@ -1,0 +1,324 @@
+# MtconnectTranspiler.CodeGenerators.ScribanTemplates
+
+`MtconnectTranspiler.CodeGenerators.ScribanTemplates` is a reusable Scriban rendering library for MTConnect Transpiler code generators. It provides the plumbing needed to load `.scriban` templates, populate a Scriban model, render MTConnect-derived objects, and write generated files.
+
+Use this package when you are building a generator that consumes model objects from `MtconnectTranspiler` and emits text artifacts such as source code, markdown, XML, JSON, schemas, or configuration files.
+
+## Install
+
+```sh
+dotnet add package MtconnectTranspiler.CodeGenerators.ScribanTemplates
+```
+
+Or add the package reference manually:
+
+```xml
+<PackageReference Include="MtconnectTranspiler.CodeGenerators.ScribanTemplates" Version="2.7.0" />
+```
+
+The package targets `netstandard2.0`.
+
+## Core Concepts
+
+The library is built around four pieces:
+
+- `IScribanTemplateGenerator` renders templates and writes files.
+- `IFileSource` marks an object as something that can become a file. The `Filename` property determines the generated file name.
+- `ScribanTemplateAttribute` maps an `IFileSource` implementation to the template used to render it.
+- `ITemplateLoaderService` loads templates from disk or embedded resources and registers optional helper objects.
+
+During rendering, the current `IFileSource` item is available to the template as `source`.
+
+## Configure Services
+
+The dependency injection extension lives in the `MtconnectTranspiler.Extensions` namespace.
+
+```csharp
+using Microsoft.Extensions.DependencyInjection;
+using MtconnectTranspiler.CodeGenerators.ScribanTemplates;
+using MtconnectTranspiler.CodeGenerators.ScribanTemplates.Formatters;
+using MtconnectTranspiler.Extensions;
+using MtconnectTranspiler.Interpreters;
+
+var services = new ServiceCollection();
+
+services.AddLogging();
+
+services.AddScribanServices(scriban =>
+{
+    scriban.ConfigureGenerator(options =>
+    {
+        options.OutputPath = "generated";
+    });
+
+    scriban.ConfigureTemplateLoader(loader =>
+    {
+        loader.UseTemplatesPath("Templates");
+        loader.AddCodeFormatter("csharp", new CSharpCodeFormatter());
+        loader.AddMarkdownInterpreter("markdown", new PlainTextInterpreter());
+    });
+});
+
+using var provider = services.BuildServiceProvider();
+var generator = provider.GetRequiredService<IScribanTemplateGenerator>();
+```
+
+`ConfigureTemplateLoader` is required because it registers the default `ITemplateLoaderService`. Call `services.AddLogging()` before configuring Scriban services so the loader builder can resolve its logger.
+
+## Define a File Source
+
+Decorate each generated file type with `ScribanTemplateAttribute`. The attribute value is the template filename or relative template path.
+
+```csharp
+using MtconnectTranspiler.CodeGenerators.ScribanTemplates;
+
+[ScribanTemplate("class.scriban")]
+public sealed class ClassFile : IFileSource
+{
+    public string Filename { get; set; }
+
+    public string Name { get; set; }
+
+    public IReadOnlyList<string> Properties { get; set; } = Array.Empty<string>();
+}
+```
+
+The generator looks for the attribute on the generic type passed to `ProcessTemplate<T>`, so call it with the concrete decorated type.
+
+## Write a Template
+
+Create `Templates/class.scriban`:
+
+```scriban
+namespace {{ namespace }}
+{
+    public sealed class {{ source.name | to_pascal_code }}
+    {
+{{ for property in source.properties }}
+        public string {{ property | to_pascal_code }} { get; set; }
+{{ end }}
+    }
+}
+```
+
+The `source` object is the current `ClassFile`. Additional global values can be added with `UpdateModel`.
+
+## Render Files
+
+```csharp
+var outputPath = Path.GetFullPath("generated");
+Directory.CreateDirectory(outputPath);
+
+generator.UpdateModel("namespace", "Generated.MTConnect");
+
+var files = new[]
+{
+    new ClassFile
+    {
+        Filename = "Availability.cs",
+        Name = "availability",
+        Properties = new[] { "data item id", "timestamp" }
+    }
+};
+
+generator.ProcessTemplate(files, outputPath, overwriteExisting: true);
+```
+
+`ProcessTemplate` has overloads for a single item and for an enumerable. It ignores `null` items and empty collections. It writes a file only when the rendered template output is not empty.
+
+## Template Loading
+
+`IncludeSharedTemplates` is the default loader.
+
+It resolves templates in this order:
+
+1. The template path exactly as requested, when it exists on disk.
+2. The template path relative to `TemplatesPath`.
+3. An embedded resource in `ResourceAssembly` under `ResourceNamespace`.
+
+By default, `TemplatesPath` is `Templates` under the application base directory. You can override it:
+
+```csharp
+scriban.ConfigureTemplateLoader(loader =>
+{
+    loader.UseTemplatesPath(Path.Combine(AppContext.BaseDirectory, "Templates"));
+});
+```
+
+To load embedded templates, configure the assembly and resource namespace:
+
+```csharp
+scriban.ConfigureTemplateLoader(loader =>
+{
+    loader.UseResourceAssembly(
+        typeof(Program).Assembly,
+        "MyGenerator.EmbeddedTemplates");
+});
+```
+
+For an embedded resource named `MyGenerator.EmbeddedTemplates.class.scriban`, use `[ScribanTemplate("class.scriban")]`.
+
+## Built-In Template Globals
+
+The generator initializes a root Scriban model and pushes it as the global context. It includes:
+
+- `source`: the current item being rendered, available during `ProcessTemplate`.
+- `version`: the version of the `MtconnectTranspiler.CodeGenerators.ScribanTemplates` assembly.
+- Any values you add with `UpdateModel(member, value)`.
+- Built-in helper functions from `ScribanHelperMethods`.
+- MTConnect helper functions from `MTConnectHelperMethods`.
+- Registered markdown interpreters and code formatters.
+
+## Built-In Helper Functions
+
+The helper methods are imported into Scriban using Scriban's normal member naming, so they are available in templates as snake_case functions.
+
+Identifier and case helpers:
+
+```scriban
+{{ "MTConnect asset changed" | to_code_safe }}
+{{ "MTConnect asset changed" | to_pascal_case }}
+{{ "MTConnect asset changed" | to_pascal_code }}
+{{ "MTConnect asset changed" | to_camel_case }}
+{{ "MTConnect asset changed" | to_camel_code }}
+{{ "MTConnectAssetChanged" | to_snake_case }}
+{{ "MTConnectAssetChanged" | to_snake_code }}
+{{ "MTConnectAssetChanged" | to_upper_snake_code }}
+{{ "MTConnectAssetChanged" | to_lower_snake_code }}
+{{ "MTConnect asset changed" | to_kebab_case }}
+{{ "MTConnect asset changed" | to_kebab_code }}
+{{ "MTConnect asset changed" | to_upper_kebab_code }}
+{{ "MTConnect asset changed" | to_lower_kebab_code }}
+{{ "MTConnect asset changed" | to_train_case }}
+{{ "MTConnect asset changed" | to_train_code }}
+{{ "MTConnect asset changed" | to_upper_train_code }}
+{{ "MTConnect asset changed" | to_lower_train_code }}
+{{ "MTConnect asset changed" | to_upper_case }}
+{{ "MTConnect asset changed" | to_lower_case }}
+```
+
+Markdown helper:
+
+```scriban
+{{ source.description | to_summary }}
+```
+
+MTConnect helpers:
+
+```scriban
+{{ normative = lookup_normative model source.id }}
+{{ deprecated = lookup_deprecated model source.id }}
+{{ version_name = lookup_mtconnect_versions "2.6" }}
+```
+
+Pass the full MTConnect `XmiDocument` or other shared model values into the template context with `UpdateModel`:
+
+```csharp
+generator.UpdateModel("model", xmiDocument);
+```
+
+## Code Formatters
+
+Register a formatter under a template name:
+
+```csharp
+loader.AddCodeFormatter("csharp", new CSharpCodeFormatter());
+loader.AddCodeFormatter("python", new PythonCodeFormatter());
+loader.AddCodeFormatter("cpp", new CppCodeFormatter());
+loader.AddCodeFormatter("javascript", new ES6JavaScriptFormatter());
+loader.AddCodeFormatter("ruby", new RubyCodeFormatter());
+```
+
+The registered formatter exposes its public one-string methods in templates:
+
+```scriban
+{{ csharp.FormatClassName source.name }}
+{{ csharp.FormatPublicPropertyName "sample property" }}
+{{ python.FormatPrivateFieldName "sample field" }}
+```
+
+Built-in formatter methods include:
+
+- `FormatClassName`
+- `FormatPublicPropertyName`
+- `FormatPrivatePropertyName`
+- `FormatPublicMethodName`
+- `FormatPrivateMethodName`
+- `FormatPublicFieldName`
+- `FormatPrivateFieldName`
+- `FormatConstantName`
+- `FormatInterfaceName`
+- `FormatEnumName`
+- `FormatEnumMemberName`
+
+Create a custom formatter by deriving from `CodeFormatter`, implementing the abstract methods, and registering it with `AddCodeFormatter`.
+
+## Markdown Interpreters
+
+Register a markdown interpreter under a template name:
+
+```csharp
+loader.AddMarkdownInterpreter("markdown", new PlainTextInterpreter());
+```
+
+The wrapper exposes explicit methods for the supported input shapes:
+
+```scriban
+{{ markdown.interpret_string source.summary }}
+{{ markdown.interpret_comment source.owned_comment }}
+{{ markdown.interpret_comments_array source.owned_comments }}
+```
+
+Use this when templates need to convert MTConnect comments or other markdown-like text into the target language's documentation style.
+
+## Overwrite Behavior
+
+`ProcessTemplate` does not overwrite existing files unless `overwriteExisting` is `true`:
+
+```csharp
+generator.ProcessTemplate(file, outputPath, overwriteExisting: true);
+```
+
+Leave this as `false` when a generator should preserve manually edited output files.
+
+## Common Patterns
+
+Use `UpdateModel` for values shared by many templates:
+
+```csharp
+generator.UpdateModel("namespace", "Generated.MTConnect");
+generator.UpdateModel("model", xmiDocument);
+generator.UpdateModel("generated_at", DateTimeOffset.UtcNow);
+```
+
+Group generated model projections by file type:
+
+```csharp
+generator.ProcessTemplate(classes, Path.Combine(outputPath, "Models"), true);
+generator.ProcessTemplate(enums, Path.Combine(outputPath, "Enums"), true);
+generator.ProcessTemplate(docs, Path.Combine(outputPath, "Docs"), true);
+```
+
+Keep templates simple by preparing generator-specific view models before calling `ProcessTemplate`. The package is intentionally focused on rendering; downstream generator projects should own model traversal, filtering, sorting, and target-language decisions.
+
+## Development
+
+The source repository is hosted at:
+
+https://github.com/mtconnect/MtconnectTranspiler.CodeGenerators.ScribanTemplates
+
+Build locally:
+
+```sh
+dotnet build MtconnectTranspiler.CodeGenerators.ScribanTemplates.sln
+```
+
+Pack locally:
+
+```sh
+dotnet pack MtconnectTranspiler.CodeGenerators.ScribanTemplates/MtconnectTranspiler.CodeGenerators.ScribanTemplates.csproj -c Release -o artifacts
+```
+
+## License
+
+This project is licensed under the Apache License 2.0.

--- a/README.md
+++ b/README.md
@@ -1,55 +1,110 @@
-[![Publish to NuGet.org](https://github.com/mtconnect/MtconnectTranspiler.Sinks.ScribanTemplates/actions/workflows/nuget-packages.yml/badge.svg)](https://github.com/mtconnect/MtconnectTranspiler.Sinks.ScribanTemplates/actions/workflows/nuget-packages.yml)
+[![Publish to NuGet.org](https://github.com/mtconnect/MtconnectTranspiler.CodeGenerators.ScribanTemplates/actions/workflows/nuget-packages.yml/badge.svg)](https://github.com/mtconnect/MtconnectTranspiler.CodeGenerators.ScribanTemplates/actions/workflows/nuget-packages.yml)
+[![NuGet](https://img.shields.io/nuget/v/MtconnectTranspiler.CodeGenerators.ScribanTemplates.svg)](https://www.nuget.org/packages/MtconnectTranspiler.CodeGenerators.ScribanTemplates/)
 
-# MtconnectTranspiler.Sinks.ScribanTemplates
+# MtconnectTranspiler.CodeGenerators.ScribanTemplates
 
-Welcome to the `MtconnectTranspiler.Sinks.ScribanTemplates` repository, an abstract sink implementation designed to facilitate file generation using the MtconnectTranspiler framework and the Scriban templating engine. This library serves as a foundation for developers looking to create custom `ITranspilerSink` implementations, leveraging the powerful Scriban syntax to generate files from the deserialized SysML model provided by the MtconnectTranspiler library.
+This repository contains the source for the `MtconnectTranspiler.CodeGenerators.ScribanTemplates` NuGet package. The library provides a reusable Scriban-based rendering layer for MTConnect Transpiler code generators. It helps generator projects turn MTConnect SysML/XMI-derived model objects into source files, documentation, configuration, or other text artifacts.
 
-## Overview
+The package is not a complete command-line generator by itself. It supplies the template loading, dependency injection registration, rendering context, helper functions, and formatter extension points that downstream MTConnect generator projects can build on.
 
-The MtconnectTranspiler framework enables the deserialization of SysML models into a structured, object-oriented format conducive for further processing. The `MtconnectTranspiler.Sinks.ScribanTemplates` library extends this capability by providing a template-based approach to generating output files, making it an ideal starting point for developers wishing to create custom outputs from the SysML model, such as code files, documentation, or configuration files.
+## Package Documentation
 
-Utilizing Scriban, a fast, powerful, and versatile templating engine (https://github.com/scriban/scriban), this library offers an "Abstract Sink" which developers can reference to complete the implementation of the `ITranspilerSink` interface defined in the MtconnectTranspiler project. 
+Full library usage is documented in the package README:
 
-## Key Features
+- [MtconnectTranspiler.CodeGenerators.ScribanTemplates/README.md](MtconnectTranspiler.CodeGenerators.ScribanTemplates/README.md)
 
-- **Scriban Templating**: Leverages Scriban's templating engine to transform the deserialized SysML model into various output formats.
-- **Abstract Sink Implementation**: Provides a skeletal framework that developers can extend to implement the `ITranspilerSink` interface, tailored to their specific output requirements.
-- **Example-Driven**: Illustrated through the `MtconnectTranspiler.Sinks.CSharp` repository, demonstrating a practical implementation of generating C# code.
+That README is included in the NuGet package and appears on the package page.
 
-## Getting Started
+## What This Library Provides
 
-To utilize the `MtconnectTranspiler.Sinks.ScribanTemplates` in your project, follow these steps:
+- Scriban template rendering through `IScribanTemplateGenerator`.
+- File generation for objects that implement `IFileSource`.
+- A `ScribanTemplateAttribute` for mapping model/output classes to `.scriban` templates.
+- Template loading from a filesystem `Templates` directory or embedded resources.
+- Dependency injection setup through `AddScribanServices`.
+- Built-in template helpers for case conversion, code-safe identifiers, MTConnect lookups, and MTConnect version aliases.
+- Pluggable markdown interpreters and code formatters.
+- Formatter implementations for C#, C++, ES6 JavaScript, Python, and Ruby naming conventions.
 
-1. **Prerequisites**:
-   - Familiarity with the MtconnectTranspiler framework and its capabilities.
-   - Basic understanding of Scriban's templating syntax.
+## Installation
 
-2. **Installation**:
-   - Clone this repository into your project.
-   - Ensure you have the MtconnectTranspiler library and Scriban installed and configured in your development environment.
+Install the package from NuGet.org:
 
-3. **Creating Your Custom Sink**:
-   - Extend the abstract classes provided by this library to implement your own `ITranspilerSink`.
-   - Utilize Scriban templates to define the output structure for your specific use case.
+```sh
+dotnet add package MtconnectTranspiler.CodeGenerators.ScribanTemplates
+```
 
-4. **Integration**:
-   - Integrate your custom sink with the MtconnectTranspiler framework to start generating output from SysML models.
+Or add a package reference manually:
 
-## Usage Example
+```xml
+<PackageReference Include="MtconnectTranspiler.CodeGenerators.ScribanTemplates" Version="2.7.0" />
+```
 
-This section would provide a simple example of extending the `MtconnectTranspiler.Sinks.ScribanTemplates` abstract sink to create a custom implementation. It will demonstrate how to define a Scriban template and use it to generate output files.
+The package targets `netstandard2.0` and depends on `MtconnectTranspiler`, `Scriban`, `CaseExtensions`, and Microsoft Extensions dependency injection/options packages.
 
-(Example code and instructions would go here)
+## Publishing
 
-## Contributing
+NuGet publishing is handled by [.github/workflows/nuget-packages.yml](.github/workflows/nuget-packages.yml).
 
-Contributions to the `MtconnectTranspiler.Sinks.ScribanTemplates` library are welcome! Please read our contributing guidelines for more information on how to report issues, submit pull requests, and contribute to the library's development.
+The workflow:
+
+1. Runs when a GitHub release is published or when manually started with `workflow_dispatch`.
+2. Checks out the repository on `windows-latest`.
+3. Installs the .NET SDK configured by the workflow.
+4. Builds `MtconnectTranspiler.CodeGenerators.ScribanTemplates/MtconnectTranspiler.CodeGenerators.ScribanTemplates.csproj` in `Release`.
+5. Packs the project into the `artifacts` directory.
+6. Uploads the `.nupkg` as a workflow artifact.
+7. Pushes `artifacts/*.nupkg` to `https://nuget.org/` using the `NUGET_TOKEN` repository secret.
+
+To publish an official package version, update the package metadata in the project file, merge the change, and publish a GitHub release. Use the manual workflow only when a maintainer intentionally wants to republish from the selected branch/ref.
+
+## Local Development
+
+Restore and build the solution:
+
+```sh
+dotnet restore MtconnectTranspiler.CodeGenerators.ScribanTemplates.sln
+dotnet build MtconnectTranspiler.CodeGenerators.ScribanTemplates.sln
+```
+
+Create a local NuGet package:
+
+```sh
+dotnet pack MtconnectTranspiler.CodeGenerators.ScribanTemplates/MtconnectTranspiler.CodeGenerators.ScribanTemplates.csproj -c Release -o artifacts
+```
+
+## Repository Layout
+
+```text
+.
+|-- .github/workflows/nuget-packages.yml
+|-- MtconnectTranspiler.CodeGenerators.ScribanTemplates.sln
+|-- MtconnectTranspiler.CodeGenerators.ScribanTemplates/
+|   |-- MtconnectTranspiler.CodeGenerators.ScribanTemplates.csproj
+|   |-- README.md
+|   |-- ScribanTemplateGenerator.cs
+|   |-- IncludeSharedTemplates.cs
+|   |-- ScribanServiceBuilder.cs
+|   |-- Formatters/
+|   `-- Attributes/
+|-- CONTRIBUTING.md
+|-- CODE_OF_CONDUCT.md
+|-- SECURITY.md
+`-- LICENSE.txt
+```
+
+## Contribution
+
+This repository is hosted under the MTConnect Institute organization on GitHub and is primarily maintained by the package maintainer. Contributions are welcome when they support MTConnect Transpiler code-generation workflows and keep the library broadly reusable.
+
+For contributions:
+
+1. Open an issue or discussion first for large API changes, release/process changes, or behavior that affects downstream generator packages.
+2. Keep pull requests focused and describe the generator scenario the change enables.
+3. Update `MtconnectTranspiler.CodeGenerators.ScribanTemplates/README.md` when changing public APIs, template behavior, helpers, formatters, or installation guidance.
+4. Include tests or a clear manual verification note for behavior changes.
+5. Follow the repository [Code of Conduct](CODE_OF_CONDUCT.md) and report security concerns through the process in [SECURITY.md](SECURITY.md).
 
 ## License
 
-This project is licensed under the Apache-2.0 License - see the LICENSE file for details.
-
-## Acknowledgments
-
-- The MtconnectTranspiler project for providing the framework for deserializing SysML models.
-- The Scriban project for offering a versatile templating engine.
+This project is licensed under the Apache License 2.0. See [LICENSE.txt](LICENSE.txt) for details.


### PR DESCRIPTION
Update package metadata and documentation for MtconnectTranspiler.CodeGenerators.ScribanTemplates: bump project version to 2.7.0.0, upgrade dependencies (Microsoft.Extensions.* -> 10.0.9, MtconnectTranspiler -> 2.7.0, Scriban -> 7.2.4), and add PackageReadmeFile support so README.md is included in the NuGet package. Add a comprehensive README.md inside the project with usage, configuration, and development instructions, and refresh the repository root README to reflect the new package name, badges, installation notes, and publishing workflow.

---
name: Pull Request
about: Suggest an improvement or a fix
title: 'Version Update: Update to v2.7'
labels: ''
assignees: ''

---
